### PR TITLE
fix warning for add_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(CATKIN_BUILD)
 
     ## Add cmake target dependencies of the executable
     ## same as for the library above
-    add_dependencies(feature_tracker_node ${PROJECT_NAME}_EXPORTED_TARGETS})
+    add_dependencies(feature_tracker_node klt_feature_tracker)
 
     ## Specify libraries to link a library or executable target against
     target_link_libraries(feature_tracker_node


### PR DESCRIPTION
gets rid of this warning during build:
```
CMake Warning (dev) at CMakeLists.txt:170 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "klt_feature_tracker_EXPORTED_TARGETS}}" of target
  "feature_tracker_node" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.
```