### PR TITLE
add dependency for srv files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(CATKIN_BUILD)
 
     ## Add cmake target dependencies of the executable
     ## same as for the library above
-    add_dependencies(feature_tracker_node klt_feature_tracker)
+    add_dependencies(feature_tracker_node klt_feature_tracker ${PROJECT_NAME}_generate_messages_cpp)
 
     ## Specify libraries to link a library or executable target against
     target_link_libraries(feature_tracker_node


### PR DESCRIPTION
feature_tracker_node.cpp depends on the generated srv files. Depending on the build order this will produce an error otherwise