### PR TITLE
cmake: bump minimum to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.6)
 project(klt_feature_tracker)
 
 unset(_CATKIN_CURRENT_PACKAGE)


### PR DESCRIPTION
CMake 3.30+ removed support for cmake_minimum_required < 3.5
```
CMake Error at external/klt_feature_tracker/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
  ```